### PR TITLE
Add SEO metadata, intro, profile, and featured posts

### DIFF
--- a/_posts/dao-the-hand.md
+++ b/_posts/dao-the-hand.md
@@ -1,0 +1,17 @@
+---
+title: "The Hand — Une DAO communautaire"
+date: "2025-08-20"
+slug: "dao-the-hand"
+coverImage: "/assets/blog/dao-the-hand/cover.jpg"
+author:
+  name: "Karim Hammouche"
+  picture: "/avatars/karim.jpg"
+excerpt: "Présentation de ma DAO : The Hand, 5 entreprises co-gérées, 99 membres chacune, tokens adossés au Bitcoin."
+ogImage:
+  url: "/og/karim-blog.png"
+---
+
+**The Hand** est une DAO communautaire innovante.  
+Chaque doigt = une entreprise, 99 membres par entreprise, token adossé au Bitcoin, redistribution mensuelle par le trésor.  
+
+Vision : gouvernance collective, valorisation des compétences, transparence.  

--- a/_posts/hello-portfolio.md
+++ b/_posts/hello-portfolio.md
@@ -1,0 +1,14 @@
+---
+title: "Bienvenue sur mon blog — objectifs & ligne éditoriale"
+date: "2025-08-17"
+slug: "hello-portfolio"
+coverImage: "/assets/blog/hello-portfolio/cover.jpg"
+author:
+  name: "Karim Hammouche"
+  picture: "/avatars/karim.jpg"
+excerpt: "Pourquoi j’écris : partager mon parcours, mes méthodes et des ressources concrètes."
+ogImage:
+  url: "/og/karim-blog.png"
+---
+
+Salut, c’est Karim. Ici, je documente mon parcours, mes projets, et les systèmes que je mets en place : automatisations, e-commerce, TypeScript/React, IA pratique et organisation.

--- a/_posts/projects-highlights.md
+++ b/_posts/projects-highlights.md
@@ -1,0 +1,14 @@
+---
+title: "Portfolio : 8 projets marquants & ce que j’y ai appris"
+date: "2025-08-18"
+slug: "projects-highlights"
+coverImage: "/assets/blog/projects-highlights/cover.jpg"
+author:
+  name: "Karim Hammouche"
+  picture: "/avatars/karim.jpg"
+excerpt: "Synthèse rapide : objectifs, stack, difficultés, résultats, leçons."
+ogImage:
+  url: "/og/karim-blog.png"
+---
+
+Je présente ici une vue d’ensemble de mes projets (freelance & perso) et les principales leçons : choix techniques, organisation, erreurs évitées.

--- a/_posts/stack-setup.md
+++ b/_posts/stack-setup.md
@@ -1,0 +1,14 @@
+---
+title: "Ma stack & setup : TypeScript, React, outils et automatisations"
+date: "2025-08-19"
+slug: "stack-setup"
+coverImage: "/assets/blog/stack-setup/cover.jpg"
+author:
+  name: "Karim Hammouche"
+  picture: "/avatars/karim.jpg"
+excerpt: "Ce que j’utilise au quotidien et pourquoi; comment je structure un projet pour livrer vite."
+ogImage:
+  url: "/og/karim-blog.png"
+---
+
+Stack : TypeScript + React (Vite sur le portfolio), UI minimaliste, automatisations, check SEO/a11y/perfs. 

--- a/data/profile.ts
+++ b/data/profile.ts
@@ -1,0 +1,18 @@
+export const profile = {
+  author: {
+    name: "Karim Hammouche",
+    role: "Développeur & entrepreneur",
+    email: "karim.hammouche1995@gmail.com",
+    avatar: "/avatars/karim.jpg",
+  },
+  links: {
+    portfolio: "https://www.karimhammouche.com",
+    github: "https://github.com/karimhammouche",
+    linkedin: "https://www.linkedin.com/in/karim-hammouche",
+  },
+  site: {
+    title: "Blog de Karim Hammouche — Ses plus beaux projets",
+    description: "Articles et notes de Karim Hammouche : parcours, projets, DAO, tech & automatisations.",
+    ogImage: "/og/karim-blog.png",
+  },
+};

--- a/src/app/_components/featured-post.tsx
+++ b/src/app/_components/featured-post.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import Image from "next/image";
+import { type Post } from "@/interfaces/post";
+
+export default function FeaturedPost({ post }: { post: Post }) {
+  return (
+    <section className="mb-16">
+      <h2 className="text-2xl font-bold mb-4">À la une</h2>
+      <Link as={`/posts/${post.slug}`} href="/posts/[slug]">
+        <div className="cursor-pointer">
+          <Image
+            src={post.coverImage}
+            alt={post.title}
+            width={1200}
+            height={600}
+            className="rounded-lg shadow-lg"
+          />
+          <h3 className="text-xl mt-4 font-semibold">{post.title}</h3>
+          <p className="text-gray-600">{post.excerpt}</p>
+        </div>
+      </Link>
+    </section>
+  );
+}

--- a/src/app/_components/intro.tsx
+++ b/src/app/_components/intro.tsx
@@ -1,21 +1,13 @@
-import { CMS_NAME } from "@/lib/constants";
-
 export function Intro() {
   return (
     <section className="flex-col md:flex-row flex items-center md:justify-between mt-16 mb-16 md:mb-12">
       <h1 className="text-5xl md:text-8xl font-bold tracking-tighter leading-tight md:pr-8">
         Blog.
       </h1>
-      <h4 className="text-center md:text-left text-lg mt-5 md:pl-8">
-        A statically generated blog example using{" "}
-        <a
-          href="https://nextjs.org/"
-          className="underline hover:text-blue-600 duration-200 transition-colors"
-        >
-          Next.js
-        </a>{" "}
-        and {CMS_NAME}.
-      </h4>
+      <p className="text-lg mt-5 md:pl-8 text-center md:text-left">
+        Notes sur mon parcours, mes projets (dont la DAO The Hand) et ma stack (TypeScript, React,
+        automatisations, IA).
+      </p>
     </section>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import Footer from "@/app/_components/footer";
-import { CMS_NAME, HOME_OG_IMAGE_URL } from "@/lib/constants";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import cn from "classnames";
@@ -10,10 +9,17 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: `Next.js Blog Example with ${CMS_NAME}`,
-  description: `A statically generated blog example using Next.js and ${CMS_NAME}.`,
+  title: "Blog de Karim Hammouche — Ses plus beaux projets",
+  description:
+    "Articles et notes de Karim Hammouche : parcours, projets, DAO, tech & automatisations.",
   openGraph: {
-    images: [HOME_OG_IMAGE_URL],
+    title: "Blog de Karim Hammouche — Ses plus beaux projets",
+    description:
+      "Articles et notes de Karim Hammouche : parcours, projets, DAO, tech & automatisations.",
+    images: ["/og/karim-blog.png"],
+  },
+  twitter: {
+    card: "summary_large_image",
   },
 };
 
@@ -23,8 +29,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="fr">
       <head>
+        <title>Blog de Karim Hammouche — Ses plus beaux projets</title>
+        <meta
+          name="description"
+          content="Articles et notes de Karim Hammouche : parcours, projets, DAO, tech & automatisations."
+        />
+        <meta
+          property="og:title"
+          content="Blog de Karim Hammouche — Ses plus beaux projets"
+        />
+        <meta
+          property="og:description"
+          content="Articles et notes de Karim Hammouche : parcours, projets, DAO, tech & automatisations."
+        />
+        <meta property="og:image" content="/og/karim-blog.png" />
+        <meta name="twitter:card" content="summary_large_image" />
         <link
           rel="apple-touch-icon"
           sizes="180x180"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import Container from "@/app/_components/container";
-import { HeroPost } from "@/app/_components/hero-post";
+import FeaturedPost from "@/app/_components/featured-post";
 import { Intro } from "@/app/_components/intro";
 import { MoreStories } from "@/app/_components/more-stories";
 import { getAllPosts } from "@/lib/api";
@@ -7,23 +7,15 @@ import { getAllPosts } from "@/lib/api";
 export default function Index() {
   const allPosts = getAllPosts();
 
-  const heroPost = allPosts[0];
-
-  const morePosts = allPosts.slice(1);
+  const featured = allPosts.find((p) => p.slug === "dao-the-hand");
+  const others = allPosts.filter((p) => p.slug !== "dao-the-hand");
 
   return (
     <main>
       <Container>
         <Intro />
-        <HeroPost
-          title={heroPost.title}
-          coverImage={heroPost.coverImage}
-          date={heroPost.date}
-          author={heroPost.author}
-          slug={heroPost.slug}
-          excerpt={heroPost.excerpt}
-        />
-        {morePosts.length > 0 && <MoreStories posts={morePosts} />}
+        {featured && <FeaturedPost post={featured} />}
+        {others.length > 0 && <MoreStories posts={others} />}
       </Container>
     </main>
   );


### PR DESCRIPTION
## Summary
- add global SEO metadata and social tags
- update intro and profile information
- add initial blog posts and featured post component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a1bf7380dc8331aae93578ab773629